### PR TITLE
Added control button

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,16 @@ const extension: JupyterFrontEndPlugin<void> = {
     const widget = new Widget({ node: logout });
     widget.addClass('jp-Button-flat');
     topBar.addItem('logout-button', widget);
+
+    const control = document.createElement('a');
+    control.id = 'control';
+    control.innerHTML = 'Control';
+    control.addEventListener('click', () => {
+    router.navigate('../../home', { hard: true }); });
+      
+    const widget_ct = new Widget({ node: control });
+    widget_ct.addClass('jp-Button-flat');
+    topBar.addItem('control-button', widget_ct);
   }
 };
 


### PR DESCRIPTION
Adds a second button to go to the hub control panel: ../../home

I find myself often changing the image spawned, and this additional button takes me to "Hub Control Panel".

Initially, I cloned the extension and replaced logout by control everywhere
https://github.com/victor-moreno/jupyterhub-deploy-docker-VM/tree/master/singleuser/srv/jupyterlab-control
but I think it makes sense to have both buttons in the same extension to save code.

Please ignore this PR if you don't like it.

Victor